### PR TITLE
Updates zmq dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Brock Whitten <brock@chloi.io>",
   "dependencies": {
-    "zmq": "2.4.0",
+    "zmq": "2.10.0",
     "commander":"1.1.1",
     "debug": "0.7.2"
   },


### PR DESCRIPTION
This updates the zmq dependency to the latest version. All tests are passing. For me at least, this is a required fix to properly use ZeroMQ with the following setup:
- ZeroMQ v3.2.5
- OS X v10.10.1 Yosemite
- Node v0.10.35

`npm install` fails otherwise and gives an error:

``` sh
> zmq@2.4.0 install /Users/Kenneth/Sites/sintaxi/waterfront/node_modules/zmq
> node-gyp rebuild

  CXX(target) Release/obj.target/zmq/binding.o
../binding.cc:28:10: fatal error: 'zmq.h' file not found
#include <zmq.h>
         ^
1 error generated.
make: *** [Release/obj.target/zmq/binding.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/Kenneth/.nvm/v0.10.35/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:820:12)
gyp ERR! System Darwin 14.0.0
```
